### PR TITLE
Add grunt-contrib-sass dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-compass": "latest",
+    "grunt-contrib-sass": "latest",
     "grunt-contrib-watch": "latest"
   }
 }


### PR DESCRIPTION
`npm list` command throws an error "_npm ERR! extraneous_". The error can be fixed by adding appropriate dependency in `package.json` file.
